### PR TITLE
Draining of DLQ topic, fixes

### DIFF
--- a/java/consumer/src/main/java/sionsmith/demo/kafka/config/KafkaConfig.java
+++ b/java/consumer/src/main/java/sionsmith/demo/kafka/config/KafkaConfig.java
@@ -2,8 +2,6 @@ package sionsmith.demo.kafka.config;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.kafka.clients.admin.NewTopic;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,7 +10,6 @@ import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.listener.ContainerProperties;
-import org.springframework.kafka.support.converter.BytesJsonMessageConverter;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/java/consumer/src/main/java/sionsmith/demo/kafka/config/KafkaConsumerProperties.java
+++ b/java/consumer/src/main/java/sionsmith/demo/kafka/config/KafkaConsumerProperties.java
@@ -21,5 +21,5 @@ public class KafkaConsumerProperties {
     private String saslJaasConfig;
     private String securityProtocol;
     private String saslMechanism;
-    private String retryConsumerGroupId;
+    private String sourceTopicPickerConsumerGroupId;
 }

--- a/java/consumer/src/main/java/sionsmith/demo/kafka/consumer/DLQConsumer.java
+++ b/java/consumer/src/main/java/sionsmith/demo/kafka/consumer/DLQConsumer.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
@@ -14,26 +15,27 @@ import sionsmith.demo.kafka.services.ShipmentEventService;
 
 @Component
 @Slf4j
-public class ErrorEventConsumer {
+public class DLQConsumer {
+
+    @Value("${spring.kafka.consumer.dlq-topic-name}")
+    private String dlqTopic;
 
     @Autowired
     private ShipmentEventService shipmentEventService;
 
-    @KafkaListener(topics = {"${spring.kafka.consumer.error-topic-name}"}, autoStartup="${spring.kafka.consumer.error-drain-enabled}")
+    @KafkaListener(topics = {"${spring.kafka.consumer.dlq-topic-name}"},
+            autoStartup="${spring.kafka.consumer.dlq-drain-enabled}",
+            groupId = "${spring.kafka.consumer.dlq-group-id}"
+    )
     public void onMessage(ConsumerRecord<String, Object> consumerRecord, Acknowledgment acknowledgment) throws JsonProcessingException {
-        log.info("Sink retry message: {}", consumerRecord);
+        log.info("DLQ message: {}", consumerRecord);
         try {
             String value = (String) consumerRecord.value();
             ObjectMapper objectMapper = new ObjectMapper();
             JsonNode jsonNode = objectMapper.readTree(value);
-            //map node to Error event class
-            ErrorEvent errorEvent = objectMapper.treeToValue(jsonNode, ErrorEvent.class);
 
-            Long offset = Long.parseLong(errorEvent.getHeaderValue(ErrorEvent.INPUT_RECORD_OFFSET));
-            Integer partition = Integer.parseInt(errorEvent.getHeaderValue(ErrorEvent.INPUT_RECORD_PARTITION));
-            String sourceTopic = errorEvent.getHeaderValue(ErrorEvent.INPUT_RECORD_TOPIC);
-            log.info("Attempted to re-process message from topic: " + sourceTopic + " using offset: " + offset + " on partition: " + partition);
-            shipmentEventService.reProcessFailedEvent(sourceTopic, offset, partition);
+            log.info("Attempted to re-process message from topic: " + this.dlqTopic);
+            shipmentEventService.reProcessDlqMessage(jsonNode);
             //commit offset
             acknowledgment.acknowledge();
 

--- a/java/consumer/src/main/java/sionsmith/demo/kafka/consumer/ErrorEventConsumer.java
+++ b/java/consumer/src/main/java/sionsmith/demo/kafka/consumer/ErrorEventConsumer.java
@@ -20,8 +20,8 @@ public class ErrorEventConsumer {
     private ShipmentEventService shipmentEventService;
 
     @KafkaListener(topics = {"${spring.kafka.consumer.error-topic-name}"}, autoStartup="${spring.kafka.consumer.error-drain-enabled}")
-    public void onMessage(ConsumerRecord<String, Object> consumerRecord, Acknowledgment acknowledgment) throws JsonProcessingException {
-        log.info("Sink retry message: {}", consumerRecord);
+    public void onMessage(ConsumerRecord<String, Object> consumerRecord, Acknowledgment acknowledgment) throws Exception {
+        log.info("Received error topic message: {}", consumerRecord.toString());
         try {
             String value = (String) consumerRecord.value();
             ObjectMapper objectMapper = new ObjectMapper();
@@ -32,15 +32,17 @@ public class ErrorEventConsumer {
             Long offset = Long.parseLong(errorEvent.getHeaderValue(ErrorEvent.INPUT_RECORD_OFFSET));
             Integer partition = Integer.parseInt(errorEvent.getHeaderValue(ErrorEvent.INPUT_RECORD_PARTITION));
             String sourceTopic = errorEvent.getHeaderValue(ErrorEvent.INPUT_RECORD_TOPIC);
-            log.info("Attempted to re-process message from topic: " + sourceTopic + " using offset: " + offset + " on partition: " + partition);
+            log.info("Will attempt to re-process message from topic: " + sourceTopic + " using offset: " + offset + " on partition: " + partition);
             shipmentEventService.reProcessFailedEvent(sourceTopic, offset, partition);
             //commit offset
             acknowledgment.acknowledge();
 
         } catch (JsonProcessingException e) {
-            log.error("Failed parses Json message.");
+            log.error("Failed parses Json message");
+            throw e;
         } catch (Exception e) {
-            log.error("Failed re process message caused by: ", e.getMessage());
+            log.error("Failed re process message");
+            throw e;
         }
     }
 }

--- a/java/consumer/src/main/java/sionsmith/demo/kafka/services/KafkaPicker.java
+++ b/java/consumer/src/main/java/sionsmith/demo/kafka/services/KafkaPicker.java
@@ -1,35 +1,43 @@
 package sionsmith.demo.kafka.services;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.TopicPartition;
 
 import java.time.Duration;
 import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.NoSuchElementException;
 import java.util.Properties;
 
+@Slf4j
 public class KafkaPicker implements AutoCloseable {
 
     private static final Duration POLL_TIMEOUT = Duration.ofSeconds(1);
 
     private String topicName;
-    private KafkaConsumer<String, JsonNode> consumer;
+    private KafkaConsumer<String, LinkedHashMap> consumer;
 
     public KafkaPicker(String topicName, Properties properties) {
         this.topicName = topicName;
         consumer = new KafkaConsumer<>(properties);
     }
 
-    public JsonNode pick(Long offset, Integer partition) {
+    public ConsumerRecord<String, LinkedHashMap> pick(Long offset, Integer partition) {
         TopicPartition topicPartition = new TopicPartition(topicName, partition);
         consumer.assign(Collections.singletonList(topicPartition));
         consumer.seek(topicPartition, offset);
 
-        ConsumerRecords<String, JsonNode> records = consumer.poll(POLL_TIMEOUT);
-        ObjectMapper objectMapper = new ObjectMapper();
-        return objectMapper.valueToTree(records.iterator().next().value());
+        ConsumerRecords<String, LinkedHashMap> records = consumer.poll(POLL_TIMEOUT);
+        try {
+            return records.iterator().next();
+        } catch (NoSuchElementException e) {
+            log.error(String.format("There is no message with offset: %d, partition: %d in the source topic.",
+                    offset, partition), e);
+            throw e;
+        }
     }
 
     public void close() {

--- a/java/consumer/src/main/java/sionsmith/demo/kafka/services/ShipmentEventService.java
+++ b/java/consumer/src/main/java/sionsmith/demo/kafka/services/ShipmentEventService.java
@@ -1,8 +1,11 @@
 package sionsmith.demo.kafka.services;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.extern.slf4j.Slf4j;
-import org.json.JSONArray;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -12,9 +15,10 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.lambda.LambdaClient;
 import software.amazon.awssdk.services.lambda.model.InvokeRequest;
 import software.amazon.awssdk.services.lambda.model.InvokeResponse;
-import software.amazon.awssdk.services.lambda.model.LambdaException;
 
 import javax.annotation.PostConstruct;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
 import java.util.Properties;
 
 @Service
@@ -32,12 +36,12 @@ public class ShipmentEventService {
     private KafkaConsumerProperties kafkaConsumerProperties;
 
     private Properties shipmentTopicProperties;
+
     @PostConstruct
     private void init() {
         client = LambdaClient.builder()
                 .region(Region.of(awsRegion))
                 .build();
-
         shipmentTopicProperties = new Properties();
         shipmentTopicProperties.put("bootstrap.servers", kafkaConsumerProperties.getBootstrapServers());
         shipmentTopicProperties.put("group.id", kafkaConsumerProperties.getSourceTopicPickerConsumerGroupId());
@@ -48,59 +52,74 @@ public class ShipmentEventService {
         shipmentTopicProperties.put("security.protocol", kafkaConsumerProperties.getSecurityProtocol());
         shipmentTopicProperties.put("sasl.jaas.config", kafkaConsumerProperties.getSaslJaasConfig());
         shipmentTopicProperties.put("sasl.mechanism", kafkaConsumerProperties.getSaslMechanism());
+
+
     }
 
     public void reProcessFailedEvent(String sourceTopic, Long offset, Integer partition) throws Exception {
         try (KafkaPicker kafkaPicker = new KafkaPicker(sourceTopic, shipmentTopicProperties)) {
-            JsonNode payload = (JsonNode) kafkaPicker.pick(offset, partition);
-            log.info("Retrived payload from offset: " + " Payload: " + payload.toPrettyString());
-            for (int retries = 0; ; retries++) {
-                try {
-                    //Invoke the Lambda function
-                    InvokeResponse response = client.invoke(InvokeRequest.builder()
-                            .functionName(lambdaFunctionName)
-                            .invocationType("RequestResponse")
-                            .payload(SdkBytes.fromUtf8String(new JSONArray().put(payload).toString()))
-                            .build());
+            ConsumerRecord<String, LinkedHashMap> record = kafkaPicker.pick(offset, partition);
+            log.info(String.format("Retrieved payload from offset: %d, partition: %d, key: %s Payload: %s",
+                    offset,
+                    partition,
+                    record.key(),
+                    record.value().toString()));
 
-                    log.debug("Lambda Response: " + response.statusCode());
-                    break;
-                } catch (LambdaException e) {
-                    if (retries < 3) {
-                        continue; // try calling the lambda again
-                    } else {
-                        log.error("Failed to process payload from offset: " + offset + " partition: " + partition + "caused by:", e);
-                        throw e;
-                    }
-                }
-            }
+            invokeShipmentProcessingLambda(record);
         } catch (Exception e) {
-            log.error("Failed to read message from offset: " + offset + " partition: " + partition + " Caused by: ", e);
+            log.error(String.format("Failed to process message from offset: %d, partition: %d ", offset, partition));
             throw e;
         }
     }
 
-    public void reProcessDlqMessage(JsonNode message) {
+    public void invokeShipmentProcessingLambda(ConsumerRecord<String, LinkedHashMap> record) throws Exception {
         for (int retries = 0; ; retries++) {
             try {
+                //build payload object as Lambda expects (same as sink connector)
+                String payload = buildPayloadArray(record);
                 //Invoke the Lambda function
                 InvokeResponse response = client.invoke(InvokeRequest.builder()
                         .functionName(lambdaFunctionName)
                         .invocationType("RequestResponse")
-                        .payload(SdkBytes.fromUtf8String(message.toString()))
+                        .payload(SdkBytes.fromUtf8String(payload))
                         .build());
 
-                log.debug("Lambda Response: " + response.statusCode());
+                log.info("Lambda was invoked. Response: " + response.statusCode());
+                if (response.functionError() != null || response.statusCode() != 200) {
+                    String errorMsg = String.format(
+                            "Lambda invocation returned error. Message: %s",
+                            response.payload().asString(StandardCharsets.UTF_8));
+                    throw new Exception(errorMsg);
+                }
                 break;
-            } catch (LambdaException e) {
+            } catch (Exception e) {
                 if (retries < 3) {
-                    log.warn("Lambda failed. It will be retried.");
+                    log.warn(String.format("Lambda failed with an error: %s. Another attempt will be made.", e.getMessage()));
                     continue; // try calling the lambda again
                 } else {
-                    log.error("Failed to process message from the DLQ topic.", e);
+                    log.error("After retries Lambda failed to process payload from offset.");
                     throw e;
                 }
             }
         }
+    }
+
+    private String buildPayloadArray(ConsumerRecord<String, LinkedHashMap> record) throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+
+        ObjectNode rootNode = mapper.createObjectNode();
+
+        ObjectNode childNode1 = mapper.createObjectNode();
+        childNode1.put("timestamp", record.timestamp());
+        childNode1.put("topic", record.topic());
+        childNode1.put("partition", record.partition());
+        childNode1.put("offset", record.offset());
+        childNode1.put("key", String.valueOf(record.key()));
+        childNode1.put("value", mapper.valueToTree(record.value()));
+        rootNode.set("payload", childNode1);
+
+        ArrayNode arr = mapper.createArrayNode();
+        arr.add(rootNode);
+        return mapper.writeValueAsString(arr);
     }
 }

--- a/java/consumer/src/main/resources/application.yaml
+++ b/java/consumer/src/main/resources/application.yaml
@@ -3,7 +3,7 @@ spring:
     use.type.headers: false
   kafka:
     consumer:
-      group-id: "error-retry-consumer-group-1"
+      group-id: "error-topic-consumer-group"
       bootstrap-servers: "127.0.0.1:9092"
       enable-auto-commit: false
       auto-offset-reset: earliest
@@ -16,8 +16,12 @@ spring:
       ssl-endpoint-identification-algorithm: https
       sasl-mechanism: PLAIN
       error-topic-name: "shipment-service-lambda-sink-error"
+      dlq-topic-name: "infoaxs.connectors.shipment-service-lambda-sink-dlq"
       spring-json-trusted-packages: "*"
-      retry-consumer-group-id: "retry-failed-sink-group-1"
+      source-topic-picker-consumer-group-id: "source-topic-picker-consumer-group"
+      dlq-consumer-group-id: "dlq-consumer-group"
+      error-drain-enabled: true
+      dlq-drain-enabled: true
 
 lambda:
   function-name: "shipment-process-dev-index"

--- a/java/consumer/src/main/resources/application.yaml
+++ b/java/consumer/src/main/resources/application.yaml
@@ -3,7 +3,7 @@ spring:
     use.type.headers: false
   kafka:
     consumer:
-      group-id: "error-topic-consumer-group"
+      group-id: "error-topic-drain-consumer-group"
       bootstrap-servers: "127.0.0.1:9092"
       enable-auto-commit: false
       auto-offset-reset: earliest
@@ -15,17 +15,17 @@ spring:
       sasl-jaas-config: org.apache.kafka.common.security.plain.PlainLoginModule required username="${CCLOUD_API_KEY}" password="${CCLOUD_API_SECRET}";
       ssl-endpoint-identification-algorithm: https
       sasl-mechanism: PLAIN
+      dlq-topic-name: "shipment-service-lambda-sink-dlq"
       error-topic-name: "shipment-service-lambda-sink-error"
-      dlq-topic-name: "infoaxs.connectors.shipment-service-lambda-sink-dlq"
       spring-json-trusted-packages: "*"
       source-topic-picker-consumer-group-id: "source-topic-picker-consumer-group"
-      dlq-consumer-group-id: "dlq-consumer-group"
+      dlq-consumer-group-id: "dlq-topic-drain-consumer-group"
       error-drain-enabled: true
-      dlq-drain-enabled: true
+      dlq-drain-enabled: false
 
 lambda:
   function-name: "shipment-process-dev-index"
-  region: "eu-west-2"
+  region: "eu-west-1"
 
 endpoints.jmx.enabled: true
 spring.jmx.enabled: true


### PR DESCRIPTION
1. Allow draining of DLQ topic
2. Fixes in building the Lambda payload
3. Stop consumption on message error